### PR TITLE
Added .env file compatability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ env
 *.DS_Store
 *.pyc
 __pycache__
-
+.env
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ Game for Pragyan
 1. Clone the repository and move into that directory
 2. Create a virtual environment by `virtualenv env`
 3. Activate the virtual environment `source env/bin/activate`
-4. Run `pip -r requirements.txt` to install requirements
-5. Set environment variables for MySQL database configuration by executing 
-    - `export DB_USER = <user>` 
-    - `export DB_PASSWORD = <password>` 
-    - `export DB_NAME = <name>`
-6. Change directory to beerf and run `python manage.py runserver` to start local development server
+4. Run `pip install -r requirements.txt` to install requirements
+5.Change directory to beerf
+6.Create a file called .env and add environment variables for MySQL Database
+    - `DB_USER=<user>` 
+    - `DB_PASSWORD=<password>` 
+    - `DB_NAME=<name>`
+8. Run python manage.py migrate to initiate the database  
+7. run `python manage.py runserver` to start local development server

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Game for Pragyan
 2. Create a virtual environment by `virtualenv env`
 3. Activate the virtual environment `source env/bin/activate`
 4. Run `pip install -r requirements.txt` to install requirements
-5.Change directory to beerf
-6.Create a file called .env and add environment variables for MySQL Database
+5. Change directory to beerf
+6. Create a file called .env and add environment variables for MySQL Database
     - `DB_USER=<user>` 
     - `DB_PASSWORD=<password>` 
     - `DB_NAME=<name>`
-8. Run python manage.py migrate to initiate the database  
-7. run `python manage.py runserver` to start local development server
+7. Run python manage.py migrate to initiate the database  
+8. run `python manage.py runserver` to start local development server

--- a/beerf/beerf/settings.py
+++ b/beerf/beerf/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
+from getenv import env
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -78,9 +79,9 @@ WSGI_APPLICATION = 'beerf.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
-        'NAME': os.environ.get("DB_NAME"),
-        'USER': os.environ.get("DB_USER"),
-        'PASSWORD': os.environ.get("DB_PASSWORD"),
+        'NAME': env("DB_NAME"),
+        'USER': env("DB_USER"),
+        'PASSWORD': env("DB_PASSWORD"),
 
     }
 }

--- a/beerf/manage.py
+++ b/beerf/manage.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import os
 import sys
+import dotenv
+dotenv.read_dotenv(os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env'))
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "beerf.settings")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 Django==1.9
+django-dotenv==1.3.0
+django-getenv==1.3.1
 MySQL-python==1.2.5
 wheel==0.24.0


### PR DESCRIPTION
The environment variables need not be exported through bash anymore. The environment variables can be set in a .env file which should be stored in /beerfactory-pragyan/beerf/ directory. The environment file is read by django-dotenv and the the variables are set using django-getenv.
